### PR TITLE
Add Compute API docs changelog entry

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -4,6 +4,24 @@ description: "Product updates and announcements"
 sidebarTitle: "Product updates"
 ---
 
+<Update label="August 2026" description="Public Compute API">
+  > ## Build and manage Compute instances through the Hivenet API.
+
+  **Public Compute API documentation**
+
+  The new [Compute API documentation](/public-api) is now available for developers building scripts, tools, and integrations with Hivenet.
+
+  The documentation covers:
+
+  - Creating, listing, starting, stopping, and terminating instances
+  - Registering and retrieving SSH keys
+  - Listing available regions and hardware presets
+  - Authentication, pagination, error handling, and rate limits
+  - Request and response examples for every documented endpoint
+
+  See the [API changelog](/public-api/changelog) for endpoint additions and changes that may affect your integration.
+</Update>
+
 <Update label="May 2026" description="v1.32">
   > ## More accurate instance availability, Falcon-OCR inference, and more predictable networking.
 
@@ -30,7 +48,7 @@ sidebarTitle: "Product updates"
   Per-instance network controls now apply to both VM and container instances, helping make network behavior more predictable and reducing noisy-neighbor variability.
 </Update>
 
-<Update label="November 2026" description="v1.31">
+<Update label="May 2026" description="v1.31">
   > ## More reliable GPU VM restarts, cleaner billing, and easier instance access.
 
   **GPU VM reliability improved**


### PR DESCRIPTION
Adds an August 2026 product changelog entry announcing the public Compute API documentation and corrects the v1.31 release label from November 2026 to May 2026.

<!-- mintlify-editor-comments:start -->
Mintlify
---
0 threads from 0 users in Mintlify

- No unresolved comments
<!-- mintlify-editor-comments:end -->

<!-- mintlify-comment-->

<a href="https://app.mintlify.com/hivenet/hivenet/editor/admin-mcp%2Fapi-docs-changelog-b5bac7c?preview=%2Fchangelog&source=pr_comment" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://d3gk2c5xim1je2.cloudfront.net/assets/review-mintlify-editor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://d3gk2c5xim1je2.cloudfront.net/assets/review-mintlify-editor-light.svg"><img src="https://d3gk2c5xim1je2.cloudfront.net/assets/review-mintlify-editor-light.svg" alt="Review in Mintlify"></picture></a>

<!-- /mintlify-comment -->