### PR TITLE
Align public API docs with final release spec

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -5,7 +5,7 @@ sidebarTitle: "Product updates"
 ---
 
 <Update label="August 2026" description="Public Compute API">
-  > ## Build and manage Compute instances through the Hivenet API.
+  > ## Manage existing Compute instances through the Hivenet API.
 
   **Public Compute API documentation**
 
@@ -13,8 +13,8 @@ sidebarTitle: "Product updates"
 
   The documentation covers:
 
-  - Creating, listing, starting, stopping, and terminating instances
-  - Registering and retrieving SSH keys
+  - Listing, inspecting, starting, stopping, and terminating existing instances
+  - Reading recent instance logs
   - Listing available regions and hardware presets
   - Authentication, pagination, error handling, and rate limits
   - Request and response examples for every documented endpoint

--- a/docs.json
+++ b/docs.json
@@ -172,12 +172,10 @@
             "pages": [
               "public-api/endpoints/list-instances",
               "public-api/endpoints/get-instance",
-              "public-api/endpoints/start-instance",
-              "public-api/endpoints/terminate-instance",
-              "public-api/endpoints/stop-instance",
               "public-api/endpoints/get-instance-logs",
-              "public-api/endpoints/create-ssh-key",
-              "public-api/endpoints/get-ssh-key",
+              "public-api/endpoints/start-instance",
+              "public-api/endpoints/stop-instance",
+              "public-api/endpoints/terminate-instance",
               "public-api/endpoints/list-regions",
               "public-api/endpoints/list-presets"
             ]

--- a/public-api/api-changelog.mdx
+++ b/public-api/api-changelog.mdx
@@ -5,140 +5,73 @@ description: "Track Compute API changes that may affect requests, responses, aut
 slug: "/public-api/changelog"
 ---
 
-Use this page to track changes to the Compute API that may affect your scripts, tools, or integrations.
-
-The endpoint reference shows the current API details. The changelog helps you understand what changed over time, especially when a request, response field, authentication behavior, or error response changes.
-
-<Tip>
-  If you’re building against the API, check the changelog before updating your integration or debugging behavior that recently changed.
-</Tip>
+Use this page to track changes to the Compute API that may affect scripts, tools, or integrations.
 
 ## Current API version
 
-The public Compute API uses versioned paths.
+Production base URL:
 
-Current version:
+`https://api.hivecompute.ai/v1`
 
-`https://api.hivenet.com/v1`
+Staging base URL:
 
-Endpoint details, supported parameters, response schemas, and examples are available in the endpoint reference pages, such as [List instances](/public-api/endpoints/list-instances), [Get instance](/public-api/endpoints/get-instance), and [Start instance](/public-api/endpoints/start-instance).
+`https://staging-api.hivecompute.ai/v1`
 
-## How to read changelog entries
-
-Each changelog entry should tell you:
-
-- What changed
-- Which endpoints or resources are affected
-- Whether you need to update your integration
-- Whether the change is backward-compatible
-- What to do next, if action is needed
-
-Changes are grouped by date, with the newest updates first.
-
-## Change types
-
-| Type | What it means |
-| :-- | :-- |
-| Added | A new endpoint, field, parameter, status, or documented behavior is available. |
-| Changed | Existing behavior, wording, validation, or response shape has changed. |
-| Deprecated | A feature or behavior still works, but will be removed or replaced later. |
-| Removed | A feature, endpoint, field, or behavior is no longer available. |
-| Fixed | An issue was corrected without requiring most integrations to change. |
-| Security | A change affects authentication, authorization, token handling, or access behavior. |
+The current release contains eight public endpoints. The endpoint reference shows the current request and response details.
 
 ## Latest changes
 
+<Update label="08/10/2026">
+  ## API surface finalized for release
+
+  **Changed**
+
+  - Production base URL is now `https://api.hivecompute.ai/v1`.
+  - Staging is available at `https://staging-api.hivecompute.ai/v1`.
+  - Region values are `UAE`, `FR`, and `US`.
+  - Instance logs are returned newest first. `entries[0]` is the most recent line.
+  - Start, stop, and terminate can return `409 Conflict` with error code `CONFLICT` when the requested action conflicts with the current lifecycle state.
+  - `500` responses use the generic message `An internal error occurred.` Clients should use `error.code`, not `error.message`, for program logic.
+  - `429` responses include `Retry-After` and use the standard error envelope.
+
+  **Removed from this release**
+
+  - `POST /ssh-keys`
+  - `GET /ssh-keys/{id}`
+
+  SSH-key operations are not backed by the released public API and will return in a later release.
+</Update>
+
 <Update label="07/29/2026">
-  ## New endpoints: stop, SSH keys, regions, and presets
+  ## Public API documentation prepared
 
-  **Added**
-
-  - [`POST /instances/{id}/stop`](/public-api/endpoints/stop-instance) — stop a running instance without terminating it.
-  - [`POST /ssh-keys`](/public-api/endpoints/create-ssh-key) — register an SSH public key on your account.
-  - [`GET /ssh-keys/{id}`](/public-api/endpoints/get-ssh-key) — retrieve one of your registered SSH keys.
-  - [`GET /regions`](/public-api/endpoints/list-regions) — list regions where instances can be launched.
-  - [`GET /presets`](/public-api/endpoints/list-presets) — list hardware presets with hourly pricing.
-
-  No action required. These are new endpoints and do not change existing behavior.
+  Initial documentation covered instance lifecycle operations, logs, regions, presets, and planned SSH-key operations. The release surface was subsequently narrowed and finalized in the August update above.
 </Update>
 
-<Update label="07/07/2026">
-  ## First version of API docs uploaded
+## Current endpoints
 
-  No API changes have been added to this changelog yet.
-</Update>
-
-When changes are published, entries will appear here with the affected endpoints and any required action.
+- [`GET /instances`](/public-api/endpoints/list-instances)
+- [`GET /instances/{id}`](/public-api/endpoints/get-instance)
+- [`GET /instances/{id}/logs`](/public-api/endpoints/get-instance-logs)
+- [`POST /instances/{id}/start`](/public-api/endpoints/start-instance)
+- [`POST /instances/{id}/stop`](/public-api/endpoints/stop-instance)
+- [`POST /instances/{id}/terminate`](/public-api/endpoints/terminate-instance)
+- [`GET /regions`](/public-api/endpoints/list-regions)
+- [`GET /presets`](/public-api/endpoints/list-presets)
 
 ## What counts as a breaking change
 
-A breaking change is a change that may require you to update code that already works.
+A breaking change may require you to update code that already works. Examples include removing an endpoint or field, changing a field type, changing authentication behavior, or making an existing request parameter required.
 
-Examples include:
-
-- Removing an endpoint
-- Removing or renaming a response field
-- Removing a supported query parameter
-- Changing a field type
-- Changing the meaning of a status value
-- Requiring a new request body field for an existing endpoint
-- Changing authentication behavior in a way that affects existing tokens
-
-\<Danger\> Do not assume undocumented fields will stay available. Build integrations against the fields documented in the API reference. \</Danger\>
-
-## What usually does not require action
-
-Some changes should not break existing integrations.
-
-Examples include:
-
-- Adding a new optional response field
-- Adding a new optional query parameter
-- Improving descriptions or examples in the docs
-- Adding a new endpoint
-- Adding a new error message for a case that already failed
-- Fixing a bug without changing the documented request or response shape
-
-\<Note\> Your code should ignore response fields it doesn’t use. This helps your integration keep working when new optional fields are added. \</Note\>
+<Danger>
+  Don't rely on undocumented fields or behavior. Build integrations against the published API reference.
+</Danger>
 
 ## How to stay compatible
 
-Use these habits when building against the API:
-
 - Use the versioned base URL shown in the docs.
-- Read endpoint details from the relevant endpoint reference page.
-- Handle unknown optional fields safely.
-- Check resource state before retrying actions.
-- Treat destructive actions, such as [terminating an instance](/public-api/endpoints/terminate-instance), with extra care.
-- Avoid relying on undocumented behavior.
-- Review this changelog when something changes unexpectedly.
-
-## When to check this page
-
-Check the changelog when:
-
-- An integration starts behaving differently
-- You update code that calls the API
-- You add support for a new endpoint
-- You see a new response field or status
-- You receive a different error response than before
-- You’re preparing a script or integration for production use
-
-## Related pages
-
-For current endpoint details, use the endpoint reference pages:
-
-- [List instances](/public-api/endpoints/list-instances)
-- [Get instance](/public-api/endpoints/get-instance)
-- [Start instance](/public-api/endpoints/start-instance)
-- [Stop instance](/public-api/endpoints/stop-instance)
-- [Terminate instance](/public-api/endpoints/terminate-instance)
-- [Get instance logs](/public-api/endpoints/get-instance-logs)
-- [Register SSH key](/public-api/endpoints/create-ssh-key)
-- [Get SSH key](/public-api/endpoints/get-ssh-key)
-- [List regions](/public-api/endpoints/list-regions)
-- [List presets](/public-api/endpoints/list-presets)
-
-For safe request handling, see [Handle errors and rate limits](/public-api/handle-errors-and-rate-limits).
-
-For instance workflows, see [Work with instances](/public-api/work-with-instances).
+- Build logic around documented fields and `error.code` values.
+- Treat cursors as opaque.
+- Respect `Retry-After` on `429` responses.
+- Check instance state before retrying lifecycle actions.
+- Review this changelog when integration behavior changes unexpectedly.

--- a/public-api/authenticate-api-requests.mdx
+++ b/public-api/authenticate-api-requests.mdx
@@ -5,112 +5,70 @@ description: "Learn how to send bearer tokens with Compute API requests and hand
 slug: "/public-api/authentication"
 ---
 
-The Compute API uses bearer token authentication. Every request must include an API token in the `Authorization` header.
+The Compute API uses bearer-token authentication. Every request must include an API key in the `Authorization` header.
 
-Bearer tokens let the API identify who is making the request and which Compute resources that user or organization can access.
+<Warning>
+  Treat API keys like passwords. Anyone with a valid key can act with the permissions of the account it belongs to.
+</Warning>
 
-\<Warning\> Treat API tokens like passwords. Anyone with a valid token may be able to access or change Compute resources linked to that token. \</Warning\>
+## Get an API key
 
-## Send your token in the Authorization header
+API keys are currently issued manually. Contact [support@hivenet.com](mailto:support@hivenet.com) to request one.
 
-Add your token to each request like this:
+There is no public endpoint for creating, listing, rotating, or revoking API keys in this release. If a key needs to be replaced, contact Support.
 
-```text
-Authorization: Bearer <your-api-token>
-```
+## Send your key
 
-For example:
+Add the key to every request:
 
-```text
+```bash
 curl --request GET \
-  --url "https://api.hivenet.com/v1/instances" \
-  --header "Authorization: Bearer YOUR_API_TOKEN" \
+  --url "https://api.hivecompute.ai/v1/instances" \
+  --header "Authorization: Bearer YOUR_API_KEY" \
   --header "Accept: application/json"
 ```
 
-## Use an environment variable
+For local testing, you can store it in an environment variable:
 
-For local testing, you can store your token in an environment variable so you don’t paste it into every command.
-
-```text
-export HIVENET_API_TOKEN="YOUR_API_TOKEN"
+```bash
+export HIVENET_API_KEY="YOUR_API_KEY"
 ```
 
-Then use it in your request:
+Then reference it in requests:
 
-```text
+```bash
 curl --request GET \
-  --url "https://api.hivenet.com/v1/instances" \
-  --header "Authorization: Bearer $HIVENET_API_TOKEN" \
+  --url "https://api.hivecompute.ai/v1/instances" \
+  --header "Authorization: Bearer $HIVENET_API_KEY" \
   --header "Accept: application/json"
 ```
 
 <Tip>
-  Environment variables are useful for local testing, but they’re not a full secrets-management system. For production workflows, store API tokens in the secret manager used by your deployment environment.
+  Environment variables are convenient for local testing, but use your deployment environment's secret manager for production workloads.
 </Tip>
-
-## Check that your token works
-
-Use a read-only endpoint, such as [`GET /instances`](/public-api/endpoints/list-instances), to test authentication.
-
-```text
-curl --request GET \
-  --url "https://api.hivenet.com/v1/instances?size=1" \
-  --header "Authorization: Bearer $HIVENET_API_TOKEN" \
-  --header "Accept: application/json"
-```
-
-If the token is valid, the API returns `200 OK`.
-
-A successful response may still contain an empty `data` array. That usually means the token works, but there are no matching resources visible to the account or organization.
 
 ## Understand access
 
-A token can only access resources allowed by the user, organization, or access policy behind it.
+An API key is scoped to the account it belongs to. It can only see and act on that account's instances. Regions and presets are shared catalogue data.
 
-If a request succeeds for one resource but fails for another, the token may be valid but may not have access to that specific resource.
-
-For example:
-
-- [`GET /instances`](/public-api/endpoints/list-instances) may return only instances visible to your account.
-- [`GET /instances/{id}`](/public-api/endpoints/get-instance) may return `404` if the instance doesn’t exist or isn’t visible to your token.
-- Actions such as [starting an instance](/public-api/endpoints/start-instance) or [terminating an instance](/public-api/endpoints/terminate-instance) may require access to that instance.
+A successful [`GET /instances`](/public-api/endpoints/list-instances) response can contain an empty `data` array if the account has no matching instances.
 
 ## Common authentication errors
 
-| Status | What it means | What to check |
+| Status | Code | What to check |
 | :-- | :-- | :-- |
-| `401 Unauthorized` | The request is missing a valid token. | Check that the `Authorization` header exists and uses the `Bearer` format. |
-| `403 Forbidden` | The token is valid, but the request is not allowed. | Check whether the account, organization, or token has access to the resource. |
-| `404 Not Found` | The resource wasn’t found or isn’t visible to the token. | Check the resource ID, or list resources first with an endpoint such as [`GET /instances`](/public-api/endpoints/list-instances). |
-| `429 Too Many Requests` | Too many requests were sent in a short time. | Wait before retrying. Use `Retry-After` when the response includes it. |
+| `401 Unauthorized` | `UNAUTHORIZED` | Make sure the `Authorization` header exists and uses `Bearer <key>`. |
+| `403 Forbidden` | `FORBIDDEN` | The resource exists, but the key's account cannot access it. |
+| `404 Not Found` | `NOT_FOUND` | Check the resource ID. |
+| `429 Too Many Requests` | `TOO_MANY_REQUESTS` | Wait for the number of seconds in `Retry-After` before retrying. |
 
-## Keep tokens safe
+## Keep API keys safe
 
-Follow these basic rules when working with API tokens:
-
-- Don’t commit tokens to Git or other source control.
-- Don’t paste tokens into public issues, chat messages, or shared documents.
-- Don’t expose tokens in frontend code or mobile apps.
-- Don’t store tokens in plain text if your tool supports encrypted secrets.
-- Rotate tokens if they may have been exposed.
-- Revoke tokens you no longer use.
-
-Never put a Compute API token in client-side code. Anyone who can inspect the app or webpage may be able to copy the token.
-
-## Rotate or revoke tokens
-
-Rotate a token when you want to replace it with a new one. Revoke a token when it should stop working.
-
-You should revoke a token when:
-
-- A team member no longer needs access
-- A script or integration has been retired
-- A token was shared by mistake
-- A device or environment that stored the token may be compromised
-
-After revoking a token, update any scripts or integrations that still depend on it.
+- Don't commit API keys to source control.
+- Don't put them in URLs or client-side code.
+- Don't paste them into public issues, screenshots, or shared documents.
+- Replace a key through Support if it may have been exposed.
 
 ## Next step
 
-Continue with [Work with instances](/public-api/work-with-instances) to understand how instance lifecycle states behave when you use the API.
+Continue with [Work with instances](/public-api/work-with-instances) to understand instance lifecycle actions.

--- a/public-api/endpoints/create-ssh-key.mdx
+++ b/public-api/endpoints/create-ssh-key.mdx
@@ -1,6 +1,0 @@
----
-title: "Register SSH key"
-sidebarTitle: "Register SSH key"
-description: "Register a public key under your account so it can be injected into instances you launch."
-openapi: "public-v1.yaml POST /ssh-keys"
----

--- a/public-api/endpoints/get-ssh-key.mdx
+++ b/public-api/endpoints/get-ssh-key.mdx
@@ -1,6 +1,0 @@
----
-title: "Get SSH key"
-sidebarTitle: "Get SSH key"
-description: "Return one of your registered SSH public keys by ID."
-openapi: "public-v1.yaml GET /ssh-keys/{id}"
----

--- a/public-api/get-started-with-the-compute-api.mdx
+++ b/public-api/get-started-with-the-compute-api.mdx
@@ -5,91 +5,88 @@ description: "Learn how the Compute API works, what you need before using it, an
 slug: "/public-api/get-started"
 ---
 
-The Compute with Hivenet API lets you manage Compute resources programmatically instead of working only through the web console.
+The Compute with Hivenet API lets you inspect and manage existing Compute resources programmatically instead of working only through the web console.
 
-You can use the API to automate repeatable workflows, connect internal tools, check the state of your resources, or build scripts around common Compute tasks. Use these guides to understand the main workflows, then use the API reference when you need exact endpoint details.
+Use these guides to understand the main workflows, then use the API reference for exact endpoint details.
 
 <Tip>
-  Use the guides when you want to understand how something works. Use the API reference when you need exact paths, parameters, request bodies, response schemas, and error formats.
+  Use the guides for workflow context. Use the API reference for paths, parameters, schemas, and response details.
 </Tip>
 
-## Base URL
+## Base URLs
 
-All public API requests use this base URL:
+Production:
 
-`https://api.hivenet.com/v1`
+`https://api.hivecompute.ai/v1`
 
-For example, the path `GET /instances` becomes:
+Staging:
 
-`https://api.hivenet.com/v1/instances`
+`https://staging-api.hivecompute.ai/v1`
+
+For example, `GET /instances` becomes:
+
+`https://api.hivecompute.ai/v1/instances`
 
 ## Authentication
 
-All API requests require a bearer token.
+Every request requires a bearer API key:
 
-Send your token in the `Authorization` header with every request:
+```text
+Authorization: Bearer <your-api-key>
+```
 
-`Authorization: Bearer <your-api-token>`
+API keys are currently issued manually. Contact [support@hivenet.com](mailto:support@hivenet.com) to request one.
 
 <Warning>
-  Keep API tokens private. Don’t paste them into public issues, shared documents, support tickets, screenshots, or client-side code.
+  Keep API keys private. Don't paste them into public issues, shared documents, screenshots, or client-side code.
 </Warning>
 
-## What you can do with the API
+## Current API surface
 
-The available endpoints are listed in the API reference. Depending on your account and access level, you can use the API to work with supported Compute resources such as instances, authentication tokens, SSH keys, regions, presets, users, and organizations.
+This release contains eight public endpoints:
 
-For instance workflows, you can use the API to:
+| Method | Endpoint | Use it to |
+| :-- | :-- | :-- |
+| `GET` | [`/instances`](/public-api/endpoints/list-instances) | List your instances. |
+| `GET` | [`/instances/{id}`](/public-api/endpoints/get-instance) | Get one instance. |
+| `GET` | [`/instances/{id}/logs`](/public-api/endpoints/get-instance-logs) | Read recent logs. |
+| `POST` | [`/instances/{id}/start`](/public-api/endpoints/start-instance) | Start a stopped instance. |
+| `POST` | [`/instances/{id}/stop`](/public-api/endpoints/stop-instance) | Stop a running instance. |
+| `POST` | [`/instances/{id}/terminate`](/public-api/endpoints/terminate-instance) | Permanently terminate an instance. |
+| `GET` | [`/regions`](/public-api/endpoints/list-regions) | List available regions. |
+| `GET` | [`/presets`](/public-api/endpoints/list-presets) | List hardware presets and pricing. |
 
-- [List instances](/public-api/endpoints/list-instances) visible to your account
-- [Filter instance results](/public-api/endpoints/list-instances) by status, GPU type, region, owner, organization, date range, or search text
-- [Get the current state of a single instance](/public-api/endpoints/get-instance)
-- [Start a stopped instance](/public-api/endpoints/start-instance)
-- [Stop a running instance](/public-api/endpoints/stop-instance)
-- [Terminate an instance](/public-api/endpoints/terminate-instance)
-- [Fetch recent container log output from an instance](/public-api/endpoints/get-instance-logs)
+SSH-key endpoints are not part of this release.
 
-For account and catalogue workflows, you can also:
+## Regions
 
-- [Register an SSH public key](/public-api/endpoints/create-ssh-key) to inject into instances you launch
-- [Get one of your registered SSH keys](/public-api/endpoints/get-ssh-key)
-- [List regions](/public-api/endpoints/list-regions) where instances can be launched
-- [List hardware presets](/public-api/endpoints/list-presets) with hourly pricing
+The API uses these region values:
 
-## How API actions work
+- `UAE`
+- `FR`
+- `US`
 
-Some API actions return immediately while the platform continues working in the background.
+Use the value returned by [`GET /regions`](/public-api/endpoints/list-regions) when filtering instances or presets.
 
-For example, when you [start a stopped instance](/public-api/endpoints/start-instance), the instance may move through `STARTING` before it reaches `RUNNING`. To check progress, call [`GET /instances/{id}`](/public-api/endpoints/get-instance) until the `status` field shows the state you expect.
+## How actions work
+
+Start, stop, and terminate actions are asynchronous. The API can return before the instance reaches its final state.
+
+Poll [`GET /instances/{id}`](/public-api/endpoints/get-instance) until the `status` field shows the state you expect.
 
 <Danger>
-  Terminating an instance is permanent. A terminated instance can’t be restarted, and its data is deleted.
+  Terminating an instance is permanent. A terminated instance can't be restarted, and its data is deleted.
 </Danger>
 
 ## What you’ll need
 
-Before you make your first request, make sure you have:
-
 - A Compute with Hivenet account
-- An API token
+- An API key
 - A terminal, API client, or tool that can send HTTP requests
-- Access to the resource you want to read or manage
+- Access to the instance you want to inspect or manage
 
-You don’t need an SDK to get started. A simple `curl` request is enough for your first test.
+You don't need an SDK to get started. A `curl` request is enough.
 
 ## Where to go next
 
-Start with [Make your first API request](/public-api/make-your-first-api-request) to send a read-only request and confirm that your token works.
-
-Then use the endpoint reference whenever you need exact technical details:
-
-- [List instances](/public-api/endpoints/list-instances)
-- [Get instance](/public-api/endpoints/get-instance)
-- [Start instance](/public-api/endpoints/start-instance)
-- [Stop instance](/public-api/endpoints/stop-instance)
-- [Terminate instance](/public-api/endpoints/terminate-instance)
-- [Get instance logs](/public-api/endpoints/get-instance-logs)
-- [Register SSH key](/public-api/endpoints/create-ssh-key)
-- [Get SSH key](/public-api/endpoints/get-ssh-key)
-- [List regions](/public-api/endpoints/list-regions)
-- [List presets](/public-api/endpoints/list-presets)
+Start with [Make your first API request](/public-api/make-your-first-api-request), then use the endpoint reference for exact request and response details.

--- a/public-api/handle-errors-and-rate-limits.mdx
+++ b/public-api/handle-errors-and-rate-limits.mdx
@@ -5,250 +5,117 @@ description: "Learn how the Compute API returns errors, how to read error respon
 slug: "/public-api/errors-and-rate-limits"
 ---
 
-The Compute API uses standard HTTP status codes and JSON error responses.
-
-When a request fails, check the status code first. It tells you the broad type of problem. Then read the response body for the specific message, request path, and timestamp.
-
-<Note>
-  An error response does not always mean the API is unavailable. Many errors mean the request needs a different token, parameter, resource ID, or retry strategy. Check the endpoint reference for errors documented on a specific endpoint.
-</Note>
+The Compute API uses standard HTTP status codes and a consistent JSON error envelope.
 
 ## Error response format
 
-Error responses use a standard JSON format.
-
-A typical error response looks like this:
-
-```text
-{
-  "statusCode": 401,
-  "message": "Missing API token",
-  "timestamp": "2026-06-26T10:00:00.000Z",
-  "path": "/v1/instances"
-}
-```
-
-Validation errors may include more than one message:
-
-```text
-{
-  "statusCode": 400,
-  "message": [
-    "status must be one of the following values: running, stopped, terminated"
-  ],
-  "error": "Bad Request",
-  "timestamp": "2026-06-26T10:00:00.000Z",
-  "path": "/v1/instances"
-}
-```
-
-## Error fields
-
-| Field | What it means |
-| :-- | :-- |
-| `statusCode` | The HTTP status code returned by the API. |
-| `message` | A human-readable error message. This may be a string or an array of strings. |
-| `error` | A short reason phrase. This may appear on validation errors. |
-| `timestamp` | The UTC time when the error occurred. |
-| `path` | The request path that returned the error. |
-
-<Tip>
-  When you contact support about an API error, include the endpoint, status code, timestamp, and a safe version of the error message. Don’t include your API token.
-</Tip>
-
-## Common status codes
-
-| Status | Meaning | What to do |
-| :-- | :-- | :-- |
-| `400 Bad Request` | The request is invalid. | Check query parameters, request body fields, date formats, UUIDs, and allowed values. |
-| `401 Unauthorized` | The request is missing a valid API token. | Check the `Authorization` header and bearer token format. |
-| `403 Forbidden` | The token is valid, but the action is not allowed. | Confirm the token has access to the account, organization, or resource. |
-| `404 Not Found` | The resource was not found or is not visible to the token. | Check the resource ID and confirm the token can access it. |
-| `409 Conflict` | The request conflicts with the current resource state. | Refresh the resource and check whether the action is still valid. |
-| `429 Too Many Requests` | Too many requests were sent in a short time. | Wait before retrying. Use `Retry-After` if the response includes it. |
-| `500` or higher | The API could not complete the request because of a server-side issue. | Retry later. If the issue continues, contact support with the request details. |
-
-<Note>
-  Not every endpoint returns every status code. Check the API reference for the errors documented for a specific endpoint.
-</Note>
-
-## Handle validation errors
-
-A `400 Bad Request` usually means the API understood the request, but one or more values were not valid.
-
-For example, a [`GET /instances`](/public-api/endpoints/list-instances) request may fail if `status` does not match one of the supported filter values:
-
-```text
-curl --request GET \
-  --url "https://api.hivenet.com/v1/instances?status=active" \
-  --header "Authorization: Bearer $HIVENET_API_TOKEN" \
-  --header "Accept: application/json"
-```
-
-The response may look like this:
+Errors use this structure:
 
 ```json
 {
-  "statusCode": 400,
-  "message": [
-    "status must be one of the following values: running, stopped, terminated"
-  ],
-  "error": "Bad Request",
-  "timestamp": "2026-06-26T10:00:00.000Z",
-  "path": "/v1/instances"
+  "error": {
+    "code": "NOT_FOUND",
+    "message": "Instance 7f3c... not found",
+    "request_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6"
+  }
 }
 ```
 
-To fix validation errors:
+| Field | What it means |
+| :-- | :-- |
+| `error.code` | Stable machine-readable error code. Use this in client logic. |
+| `error.message` | Human-readable explanation. Don't branch on this text. |
+| `error.request_id` | Identifies the request in Hivenet logs. Include it when contacting Support. |
 
-- Check the exact parameter name.
-- Check the value format.
-- Check allowed enum values.
-- Check UUID and date-time formatting.
-- Remove optional parameters until the request works, then add them back one by one.
+<Warning>
+  Client logic should branch on `error.code`, never on `error.message`. Messages can change without changing the underlying error condition.
+</Warning>
 
-## Handle authentication errors
+## Common error codes
 
-A `401 Unauthorized` response means the request did not include a valid token.
+| Status | Code | Meaning |
+| :-- | :-- | :-- |
+| `400 Bad Request` | `VALIDATION_ERROR` | A parameter or request value is invalid. |
+| `401 Unauthorized` | `UNAUTHORIZED` | The API key is missing or invalid. |
+| `403 Forbidden` | `FORBIDDEN` | The resource exists but the account cannot access it. |
+| `404 Not Found` | `NOT_FOUND` | The requested resource does not exist. |
+| `409 Conflict` | `CONFLICT` | The action conflicts with the instance's current lifecycle state. |
+| `429 Too Many Requests` | `TOO_MANY_REQUESTS` | The rate limit was exceeded. |
+| `500 Internal Server Error` | `INTERNAL_ERROR` | The server could not complete the request. |
 
-Check that the request includes the `Authorization` header:
+## Handle 409 conflicts
 
-```text
-Authorization: Bearer <your-api-token>
-```
+Start, stop, and terminate can return `409 Conflict` when the requested action conflicts with the instance's current state. For example, starting an instance that is still stopping returns `CONFLICT`.
 
-Then check these common issues:
-
-- The header is missing.
-- `Bearer` is misspelled.
-- The token was copied with extra spaces.
-- The token is expired, revoked, or invalid.
-- The request is being sent from a tool that strips headers.
-  <Warning>
-    Do not put API tokens in URLs. URLs can be stored in browser history, server logs, proxy logs, and shared screenshots.
-  </Warning>
-
-## Handle not found errors
-
-A `404 Not Found` response means the requested resource could not be found.
-
-For API users, this can mean one of two things:
-
-- The resource does not exist.
-- The resource exists, but your token cannot access it.
-
-For example, [`GET /instances/{id}`](/public-api/endpoints/get-instance) may return `404` if the instance ID is wrong, or if the instance is not visible to the user or organization linked to the token.
-
-When you see a `404`:
-
-- Check the resource ID.
-- Confirm you are using the right environment and base URL.
-- Confirm the token can access the expected account or organization.
-
-## Handle conflict errors
-
-A `409 Conflict` means the request cannot be completed because the resource is not in the right state for that action. This is most relevant for actions that change resources, such as [starting](/public-api/endpoints/start-instance) or [terminating](/public-api/endpoints/terminate-instance) an instance.
-
-For example, an action may fail if the resource is already changing state, already terminated, or not ready for the requested operation.
-
-When you see a `409`:
+When this happens:
 
 <Steps>
-  <Step title="Fetch the latest resource state">
-    Call the relevant `GET` endpoint again and check the current status.
+  <Step title="Fetch the current state">
+    Call [`GET /instances/{id}`](/public-api/endpoints/get-instance).
   </Step>
-  <Step title="Confirm the action is still valid">
-    Make sure the resource can still accept the action you want to run.
+  <Step title="Wait for the transition to finish">
+    If the instance is still starting, stopping, or terminating, wait until it reaches a stable state.
   </Step>
-  <Step title="Wait if the resource is changing state">
-    If the resource is starting, stopping, or terminating, wait before trying again.
-  </Step>
-  <Step title="Retry only when safe">
-    Retry once you know the action is still valid and won’t cause an unwanted change.
+  <Step title="Retry only if the action still makes sense">
+    Send the action again after confirming the current state.
   </Step>
 </Steps>
 
 ## Handle rate limits
 
-A `429 Too Many Requests` response means your client sent too many requests in a short time.
-
-If the response includes a `Retry-After` header, wait that many seconds before sending another request.
-
-Example response header:
+A `429 Too Many Requests` response includes a `Retry-After` header. Wait that many seconds before retrying.
 
 ```text
 Retry-After: 60
 ```
 
-A rate limit response may look like this:
+Don't pace requests against an assumed fixed limit. Treat the rate limit as subject to change and respond to `429` dynamically.
+
+## Handle server errors
+
+A `500` response uses the generic message:
 
 ```json
 {
-  "statusCode": 429,
-  "message": "Too Many Requests",
-  "timestamp": "2026-06-26T10:00:00.000Z",
-  "path": "/v1/instances"
+  "error": {
+    "code": "INTERNAL_ERROR",
+    "message": "An internal error occurred.",
+    "request_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6"
+  }
 }
 ```
 
-<Tip>
-  For scripts and integrations, add retry logic with a short delay instead of retrying immediately in a tight loop.
-</Tip>
+The message is intentionally generic. Use `error.code` for program logic and keep `request_id` for troubleshooting.
+
+For temporary server errors, retry after a short delay. If the problem continues, contact Support with the `request_id`.
 
 ## Retry safely
 
-Some requests are safer to retry than others.
-
 | Request type | Retry guidance |
-| --- | --- |
-| Read-only requests, such as [`GET /instances`](/public-api/endpoints/list-instances) | Usually safe to retry after a short delay. |
-| Requests that start, stop, update, or terminate resources | Retry carefully. Check the current resource state before trying again. |
-| Requests that failed with `400` | Don’t retry without changing the request. |
-| Requests that failed with `401` or `403` | Don’t retry until you fix access or authentication. |
-| Requests that failed with `429` | Wait before retrying. Use `Retry-After` when available. |
-| Requests that failed with `500` or higher | Retry after a delay. If the issue continues, contact support. |
+| :-- | :-- |
+| Read-only requests | Usually safe to retry after a short delay. |
+| `400` | Fix the request before retrying. |
+| `401` or `403` | Fix authentication or access before retrying. |
+| `409` | Fetch the latest instance state before retrying. |
+| `429` | Wait for `Retry-After`. |
+| `500` | Retry after a delay; contact Support if it persists. |
 
 <Danger>
-  Be careful retrying destructive actions. Before retrying a [terminate request](/public-api/endpoints/terminate-instance), fetch the resource state and confirm you still want to continue.
+  Before retrying a destructive action such as terminate, fetch the instance state and confirm the action is still needed.
 </Danger>
-
-## Build simple retry behavior
-
-A safe retry flow looks like this:
-
-<Steps>
-  <Step title="Check the status code">
-    Use the status code to decide whether the request can be retried.
-  </Step>
-  <Step title="Fix request errors first">
-    For `400`, `401`, and `403`, change the request or access setup before retrying.
-  </Step>
-  <Step title="Respect rate limit">
-    For `429`, wait for the `Retry-After` value when it is included.
-  </Step>
-  <Step title="Pause before retrying server errors">
-    For `500` or higher, wait before retrying instead of sending repeated requests immediately.
-  </Step>
-  <Step title="Check resource state after actions">
-    For actions that change resources, fetch the resource again before deciding whether another request is needed. For instances, use [`GET /instances/{id}`](/public-api/endpoints/get-instance).
-  </Step>
-</Steps>
 
 ## What to include when asking for help
 
-If you need help with an API error, include:
+Include:
 
-- The HTTP status code
-- The response `message`
-- The response `timestamp`
-- The response `path`
-- Whether the request worked before
-- What changed before the error started
+- The endpoint and HTTP method
+- The HTTP status
+- `error.code`
+- `error.request_id`
+- A redacted request if useful
 
-<Warning>
-  Never share your full API token in a support message. If you need to show a request, replace the token with a placeholder such as `Bearer REDACTED`.
-</Warning>
+Never include your API key.
 
 ## Next step
 
-Continue with [API changelog](/public-api/api-changelog) to track changes that may affect your API integrations.
+Continue with [API changelog](/public-api/api-changelog) to track API changes.

--- a/public-api/make-your-first-api-request.mdx
+++ b/public-api/make-your-first-api-request.mdx
@@ -5,54 +5,53 @@ description: "Send a read-only request to the Compute API and check that your to
 slug: "/public-api/first-request"
 ---
 
-Start with a read-only request before you try actions that change a resource.
+Start with a read-only request before you try actions that change an instance.
 
-This page uses [`GET /instances`](/public-api/endpoints/list-instances) because it’s a safe way to confirm that your API token works, your base URL is correct, and your client can read a JSON response.
-
-<Note>
-  This request lists Compute instances visible to your account. If the response is successful but the list is empty, your token may still be working. It may simply mean there are no instances available to that user or organization.
-</Note>
+This guide uses [`GET /instances`](/public-api/endpoints/list-instances) to confirm that your API key works, the base URL is correct, and your client can read a JSON response.
 
 ## Before you start
 
-Make sure you have:
+You’ll need:
 
 - A Compute with Hivenet account
-- An API token
-- A terminal or API client that can send HTTP requests
+- An API key issued for that account
+- A terminal or API client
 
-You’ll also need the public API base URL:
+Production base URL:
 
-`https://api.hivenet.com/v1`
+`https://api.hivecompute.ai/v1`
+
+Staging base URL:
+
+`https://staging-api.hivecompute.ai/v1`
+
+<Note>
+  Use the production URL for normal integrations. Use staging only when you specifically need to test against the staging API.
+</Note>
 
 ## Send a request
 
 <Steps>
-  <Step title="Prepare your API token">
-    Copy your API token from the place where your account or organization manages API access.
+  <Step title="Prepare your API key">
+    Store your key in an environment variable:
 
-    ```text
-    Keep the token private. You’ll use it in the `Authorization` header.
+    ```bash
+    export HIVENET_API_KEY="YOUR_API_KEY"
     ```
   </Step>
-  <Step title="Call the instances endpoint">
-    Send a `GET` request to [`/instances`](/public-api/endpoints/list-instances).
+  <Step title="List your instances">
+    Send a `GET` request to `/instances`:
 
-    Replace `YOUR_API_TOKEN` with your actual token before running the command.
-
-    ````text
     ```bash
     curl --request GET \
-      --url "https://api.hivenet.com/v1/instances?size=10" \
-      --header "Authorization: Bearer YOUR_API_TOKEN" \
+      --url "https://api.hivecompute.ai/v1/instances?size=10" \
+      --header "Authorization: Bearer $HIVENET_API_KEY" \
       --header "Accept: application/json"
     ```
-    ````
   </Step>
   <Step title="Check the response">
-    A successful request returns `200 OK` and a JSON response. The response includes a `data` array and pagination information. A shortened example looks like this:
+    A successful request returns `200 OK` and a JSON response with a `data` array and pagination information.
 
-    ````json
     ```json
     {
       "data": [
@@ -60,59 +59,46 @@ You’ll also need the public API base URL:
           "instance_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
           "name": "my-training-run",
           "status": "RUNNING",
-          "gpu_type": "NVIDIA_A100_80G",
-          "region": "us-east-1"
+          "gpu_type": "RTX 5090",
+          "region": "FR"
         }
       ],
       "pagination": {
-        "next": "eyJpZCI6ImExYjJjM2Q0In0",
+        "next": null,
         "size": 10
       }
     }
     ```
-    ````
   </Step>
 </Steps>
 
-## Understand the request
-
-The request uses three important pieces:
-
-| Part | What it does |
-| :-- | :-- |
-| `GET` | Reads data without changing anything. |
-| [`/instances`](/public-api/endpoints/list-instances) | Lists Compute instances visible to your account. |
-| `Authorization` | Sends your bearer token so the API can authenticate the request. |
-
-The query parameter `size=10` limits the response to 10 instances. You can remove it or change the number when you need a larger page.
+An empty `data` array can still mean authentication succeeded. It may simply mean the account has no matching instances.
 
 ## Read the response
 
-In the response, check these fields first:
-
 | Field | What it means |
 | :-- | :-- |
-| `data` | The list of instances returned by the request. |
-| `instance_id` | The unique ID of an instance. You’ll use this for instance-specific requests, such as [getting one instance](/public-api/endpoints/get-instance) or [fetching instance logs](/public-api/endpoints/get-instance-logs). |
-| `status` | The current lifecycle state of the instance. |
-| `pagination.next` | The cursor for the next page of results. If it’s `null`, there are no more pages. |
+| `data` | Instances returned by the request. |
+| `instance_id` | The ID used for instance-specific requests. |
+| `status` | The current lifecycle state. |
+| `pagination.next` | Cursor for the next page, or `null` when there are no more pages. |
 
 <Tip>
-  Save one `instance_id` from the response if you want to test instance-specific endpoints later, such as [`GET /instances/{id}`](/public-api/endpoints/get-instance) or [`GET /instances/{id}/logs`](/public-api/endpoints/get-instance-logs).
+  Save an `instance_id` if you want to test [`GET /instances/{id}`](/public-api/endpoints/get-instance) or [`GET /instances/{id}/logs`](/public-api/endpoints/get-instance-logs) next.
 </Tip>
 
 ## Common first errors
 
-| Status | What it usually means | What to do |
+| Status | Code | What to do |
 | :-- | :-- | :-- |
-| `400` | A query parameter is invalid. | Check parameter names, formats, and allowed values. |
-| `401` | The token is missing, invalid, or expired. | Check the `Authorization` header and make sure the token is correct. |
-| `429` | You’ve sent too many requests in a short time. | Wait before retrying. If the response includes `Retry-After`, use that value. |
+| `400` | `VALIDATION_ERROR` | Check query parameters and allowed values. |
+| `401` | `UNAUTHORIZED` | Check the `Authorization` header and API key. |
+| `429` | `TOO_MANY_REQUESTS` | Wait for the `Retry-After` value before retrying. |
 
 <Warning>
-  Don’t test the API for the first time with an action that changes a resource. Use read-only endpoints such as [`GET /instances`](/public-api/endpoints/list-instances) until you’re sure your token and client are working.
+  Test authentication with read-only requests before using start, stop, or terminate actions.
 </Warning>
 
 ## Next step
 
-Continue with [Authenticate API requests](/public-api/authenticate-api-requests) to learn how bearer tokens are sent, stored, and handled safely.
+Continue with [Authenticate API requests](/public-api/authenticate-api-requests) for key-handling guidance.

--- a/public-api/use-pagination-and-filters.mdx
+++ b/public-api/use-pagination-and-filters.mdx
@@ -5,218 +5,122 @@ description: "Learn how to page through API results and narrow responses with su
 slug: "/public-api/pagination-and-filters"
 ---
 
-List endpoints can return more results than you want to handle in a single response. Pagination helps you move through results safely, while filters help you ask for a smaller, more useful set of data.
-
-Use pagination when you need to process many resources. Use filters when you already know what kind of resource you’re looking for.
+List endpoints can return more results than you want to handle in one response. Cursor pagination lets you move through those results safely, while filters narrow the result set.
 
 <Note>
-  Not every list endpoint supports the same filters. For instance filters, see the [`GET /instances`](/public-api/endpoints/list-instances) endpoint reference.
+  Not every list endpoint supports the same filters. Use the endpoint reference for the exact parameters available on each endpoint.
 </Note>
 
 ## How cursor pagination works
-
-The Compute API uses cursor-based pagination for list responses that support paging.
-
-A cursor is an opaque value that points to the next page of results. You don’t need to read or modify it. Pass it back exactly as the API returns it.
 
 A paginated response includes a `pagination` object:
 
 ```json
 {
-  "data": [
-    {
-      "instance_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
-      "name": "my-training-run",
-      "status": "RUNNING"
-    }
-  ],
+  "data": [],
   "pagination": {
-    "next": "eyJpZCI6ImExYjJjM2Q0In0",
+    "next": "opaque-cursor",
     "size": 20
   }
 }
 ```
 
-If `pagination.next` contains a value, there may be another page. If `pagination.next` is `null`, you’ve reached the last page.
+If `pagination.next` contains a value, pass it back as the `cursor` query parameter. When it is `null`, you have reached the last page.
+
+<Warning>
+  Cursors are opaque. Don't edit, parse, or construct them yourself.
+</Warning>
 
 ## Request the first page
 
-To request the first page of instances, call [`GET /instances`](/public-api/endpoints/list-instances) without a cursor.
-
-```text
+```bash
 curl --request GET \
-  --url "https://api.hivenet.com/v1/instances?size=20" \
-  --header "Authorization: Bearer $HIVENET_API_TOKEN" \
+  --url "https://api.hivecompute.ai/v1/instances?size=20" \
+  --header "Authorization: Bearer $HIVENET_API_KEY" \
   --header "Accept: application/json"
 ```
-
-The `size` query parameter controls the maximum number of items returned in that page.
 
 For `GET /instances`, `size` can be between `1` and `200`. The default is `50`.
 
-<Tip>
-  Use smaller page sizes while testing. Larger pages are useful for batch jobs, but small pages make responses easier to inspect when you’re debugging.
-</Tip>
-
 ## Request the next page
 
-To request the next page, copy the value from `pagination.next` and pass it as the `cursor` query parameter.
-
-```text
+```bash
 curl --request GET \
-  --url "https://api.hivenet.com/v1/instances?size=20&cursor=eyJpZCI6ImExYjJjM2Q0In0" \
-  --header "Authorization: Bearer $HIVENET_API_TOKEN" \
+  --url "https://api.hivecompute.ai/v1/instances?size=20&cursor=opaque-cursor" \
+  --header "Authorization: Bearer $HIVENET_API_KEY" \
   --header "Accept: application/json"
 ```
 
-Keep using the next cursor from each response until `pagination.next` is `null`.
+Keep using the latest `pagination.next` value until it becomes `null`.
 
-<Warning>
-  Treat cursors as temporary values. Don’t store them as permanent links to a specific page, and don’t edit them before sending them back to the API.
-</Warning>
+## Filter instances
 
-## Page through all results
+[`GET /instances`](/public-api/endpoints/list-instances) supports filters for:
 
-A typical pagination workflow looks like this:
+| Filter | What it does |
+| :-- | :-- |
+| `status` | Filters by lifecycle status. |
+| `gpu_type` | Filters by GPU model. |
+| `region` | Filters by region. |
+| `date_range_begin` | Returns instances created at or after a timestamp. |
+| `date_range_end` | Returns instances created at or before a timestamp. |
+| `free_text_search` | Searches instance names and related searchable fields. |
 
-<Steps>
-  <Step title="Request the first page">
-    Call the list endpoint, such as [`GET /instances`](/public-api/endpoints/list-instances), with a `size` value and no `cursor`.
-  </Step>
-  <Step title="Read the response">
-    Process the items in the `data` array.
-  </Step>
-  <Step title="Check for the next cursor">
-    Look at `pagination.next`.
-  </Step>
-  <Step title="Request the next page">
-    If `pagination.next` is not `null`, send another request with that value as the `cursor`.
-  </Step>
-  <Step title="Stop at the last page">
-    Stop when `pagination.next` is `null`.
-  </Step>
-</Steps>
+The accepted region values are:
 
-## Use filters to narrow results
+- `UAE`
+- `FR`
+- `US`
 
-Filters are query parameters that reduce the results returned by a list endpoint, such as [`GET /instances`](/public-api/endpoints/list-instances).
+Example:
 
-For example, this request lists running instances in a specific region:
-
-```text
+```bash
 curl --request GET \
-  --url "https://api.hivenet.com/v1/instances?status=running&region=us-east-1&size=20" \
-  --header "Authorization: Bearer $HIVENET_API_TOKEN" \
+  --url "https://api.hivecompute.ai/v1/instances?status=running&region=FR&size=20" \
+  --header "Authorization: Bearer $HIVENET_API_KEY" \
   --header "Accept: application/json"
 ```
 
-Filters are useful when you want to:
+## Filter by date range
 
-- Find resources in a specific state
-- Limit results to a region or hardware type
-- Search by owner, organization, or related identifier
-- Review resources created during a specific time window
-- Find resources by name or other searchable text
+Use ISO 8601 timestamps in UTC:
 
-## Supported instance filters
-
-[`GET /instances`](/public-api/endpoints/list-instances) supports these filters:
-
-| Filter | Type | What it does |
-| :-- | :-- | :-- |
-| `cursor` | String | Requests the next page using a cursor from `pagination.next`. |
-| `size` | Integer | Sets the maximum number of items returned per page. |
-| `status` | String | Filters instances by lifecycle status. |
-| `gpu_type` | String | Filters instances by GPU model identifier. |
-| `region` | String | Filters instances by region slug. |
-| `host_id` | String | Filters instances running on a specific host node. |
-| `user_id` | UUID | Filters instances by owning user. |
-| `org_id` | UUID | Filters instances by organization. |
-| `date_range_begin` | Date-time | Returns instances created at or after this timestamp. |
-| `date_range_end` | Date-time | Returns instances created at or before this timestamp. |
-| `free_text_search` | String | Searches across instance names and related fields. |
-
-<Note>
-  Use the endpoint reference for exact limits, allowed values, defaults, and examples.
-</Note>
-
-## Filter by status
-
-Use `status` with [`GET /instances`](/public-api/endpoints/list-instances) when you only want instances in a specific lifecycle state.
-
-```text
+```bash
 curl --request GET \
-  --url "https://api.hivenet.com/v1/instances?status=running" \
-  --header "Authorization: Bearer $HIVENET_API_TOKEN" \
+  --url "https://api.hivecompute.ai/v1/instances?date_range_begin=2026-08-01T00:00:00Z&date_range_end=2026-08-10T23:59:59Z" \
+  --header "Authorization: Bearer $HIVENET_API_KEY" \
   --header "Accept: application/json"
 ```
-
-For `GET /instances`, supported status filters are:
-
-- `running`
-- `stopped`
-- `terminated`
-
-<Note>
-  Status filter values may use a different format from status values returned in the response. For example, a filter may use `running`, while the response may show `RUNNING`.
-</Note>
-
-Filter by date range
-
-Use `date_range_begin` and `date_range_end` together when you want instances created within a specific time window.
-
-```text
-curl --request GET \
-  --url "https://api.hivenet.com/v1/instances?date_range_begin=2026-06-01T00:00:00Z&date_range_end=2026-06-30T23:59:59Z" \
-  --header "Authorization: Bearer $HIVENET_API_TOKEN" \
-  --header "Accept: application/json"
-```
-
-Date range values use ISO 8601 timestamps in UTC.
-
-Use both parameters together:
-
-- `date_range_begin` sets the start of the range.
-- `date_range_end` sets the end of the range.
 
 ## Search by text
 
-Use `free_text_search` with [`GET /instances`](/public-api/endpoints/list-instances) when you want to search across instance names and related fields.
-
-```text
+```bash
 curl --request GET \
-  --url "https://api.hivenet.com/v1/instances?free_text_search=training-run" \
-  --header "Authorization: Bearer $HIVENET_API_TOKEN" \
+  --url "https://api.hivecompute.ai/v1/instances?free_text_search=training-run" \
+  --header "Authorization: Bearer $HIVENET_API_KEY" \
   --header "Accept: application/json"
 ```
 
-Text search is useful when you know part of a resource name but don’t know its ID.
+## List presets by region
 
-## Combine filters
+[`GET /presets`](/public-api/endpoints/list-presets) is also cursor-paginated and can be filtered by supported catalogue fields such as region.
 
-You can combine supported filters in one [`GET /instances`](/public-api/endpoints/list-instances) request.
-
-For example, this request searches for running instances in `us-east-1` that match `training-run`:
-
-```text
+```bash
 curl --request GET \
-  --url "https://api.hivenet.com/v1/instances?status=running&region=us-east-1&free_text_search=training-run&size=20" \
-  --header "Authorization: Bearer $HIVENET_API_TOKEN" \
+  --url "https://api.hivecompute.ai/v1/presets?region=FR&size=20" \
+  --header "Authorization: Bearer $HIVENET_API_KEY" \
   --header "Accept: application/json"
 ```
-
-When combining filters, start with the narrowest useful set. If the response is empty, remove filters one at a time to find which condition is excluding the resource.
 
 ## Common issues
 
 | Issue | What to check |
 | :-- | :-- |
-| The response is empty | The filters may be too narrow, or the token may not have access to matching resources. |
-| The API returns `400` | Check parameter names, allowed values, date formats, and UUID formats. |
-| The next page repeats results | Make sure you’re using the latest `pagination.next` cursor from the previous response. |
-| The cursor does not work | Request a fresh first page and use the new cursor. |
-| A date range returns unexpected results | Confirm the timestamps are in UTC and that both date range parameters are included. |
+| Response is empty | Remove filters one at a time and confirm the account has matching resources. |
+| API returns `400` | Check parameter names, allowed values, and date formats. |
+| Next page repeats results | Use the latest cursor returned by the previous response. |
+| Cursor no longer works | Request a fresh first page and use the new cursor. |
 
 ## Next step
 
-Continue with [Handle errors and rate limits](/public-api/handle-errors-and-rate-limits) to understand common API errors and how to retry requests safely.
+Continue with [Handle errors and rate limits](/public-api/handle-errors-and-rate-limits).

--- a/public-api/work-with-instances.mdx
+++ b/public-api/work-with-instances.mdx
@@ -4,49 +4,42 @@ sidebarTitle: "Instances"
 slug: "/public-api/instances"
 ---
 
-Instances are the main Compute resource you’ll work with through the API. An instance runs a workload on a selected hardware preset in a chosen region.
-
-You can use the API to check instance state, build automation around instance workflows, [start stopped work](/public-api/endpoints/start-instance), [stop running instances](/public-api/endpoints/stop-instance), [terminate resources you no longer need](/public-api/endpoints/terminate-instance), and [fetch recent logs](/public-api/endpoints/get-instance-logs) for debugging.
+Instances are the main Compute resource exposed by the public API. You can list and inspect existing instances, read recent logs, and start, stop, or terminate them.
 
 <Note>
-  If you prefer to manage instances from the web console, see [start and stop instances](/documentation/essentials/start-stop-instances) and [stop or terminate an instance](/documentation/essentials/stop-terminate-instance) in the Essentials section.
+  The current public API does not create instances. Create new instances in the Compute console, then use the API to inspect or manage them.
 </Note>
 
 ## Instance lifecycle
 
-An instance moves through lifecycle states as it is created, started, stopped, or terminated.
-
-Common states include:
+Common lifecycle states include:
 
 | Status | What it means |
 | :-- | :-- |
-| `CREATED` | The instance record exists, but the instance has not been scheduled yet. |
-| `DEPLOYED` | The instance has been scheduled on a host and is waiting to start. |
+| `CREATED` | The instance record exists but has not finished scheduling. |
+| `DEPLOYED` | The instance has been scheduled on a host. |
 | `STARTING` | The instance is booting. |
-| `RUNNING` | The instance is running and should be accessible. |
+| `RUNNING` | The instance is running. |
 | `STOPPING` | Shutdown is in progress. |
-| `STOPPED` | The instance is stopped and can be restarted. |
-| `ERRORED` | The instance hit an error state. |
-| `TERMINATED` | The instance has been permanently removed and can’t be restarted. |
+| `STOPPED` | The instance is stopped and can be started again. |
+| `ERRORED` | The instance entered an error state. |
+| `TERMINATING` | Permanent termination is in progress. |
+| `TERMINATED` | The instance has been permanently terminated. |
 
-Some actions are asynchronous. That means the API accepts the request and returns the current instance state while the platform continues working in the background.
-
-<Tip>
-  After starting or terminating an instance, poll [`GET /instances/{id}`](/public-api/endpoints/get-instance) until the `status` field shows the expected state.
-</Tip>
+Start, stop, and terminate actions are asynchronous. Poll [`GET /instances/{id}`](/public-api/endpoints/get-instance) until the instance reaches the expected state.
 
 ## List instances
 
-Use [`GET /instances`](/public-api/endpoints/list-instances) to return the instances visible to your account.
+Use [`GET /instances`](/public-api/endpoints/list-instances):
 
-```text
+```bash
 curl --request GET \
-  --url "https://api.hivenet.com/v1/instances?size=20" \
-  --header "Authorization: Bearer $HIVENET_API_TOKEN" \
+  --url "https://api.hivecompute.ai/v1/instances?size=20" \
+  --header "Authorization: Bearer $HIVENET_API_KEY" \
   --header "Accept: application/json"
 ```
 
-The response returns a `data` array and pagination details.
+The response includes a `data` array and pagination metadata.
 
 ```json
 {
@@ -55,138 +48,99 @@ The response returns a `data` array and pagination details.
       "instance_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
       "name": "my-training-run",
       "status": "RUNNING",
-      "gpu_type": "NVIDIA_A100_80G",
-      "region": "us-east-1"
+      "gpu_type": "RTX 5090",
+      "region": "FR"
     }
   ],
   "pagination": {
-    "next": "eyJpZCI6ImExYjJjM2Q0In0",
+    "next": null,
     "size": 20
   }
 }
 ```
 
-If `pagination.next` is not `null`, use it as the `cursor` query parameter to request the next page. See [Use pagination and filters](/public-api/use-pagination-and-filters) for the full pagination workflow.
-
 ## Filter instances
 
-You can filter the [`GET /instances`](/public-api/endpoints/list-instances) response when you only need a specific subset.
+Supported filters include:
 
-Common filters include:
+- `status`
+- `gpu_type`
+- `region`
+- `date_range_begin`
+- `date_range_end`
+- `free_text_search`
+- supported sort fields and direction
 
-| Filter | Use it to |
-| :-- | :-- |
-| `status` | Return instances with a specific lifecycle status. |
-| `gpu_type` | Return instances using a specific GPU model. |
-| `region` | Return instances in a specific region. |
-| `host_id` | Return instances running on a specific host node. |
-| `user_id` | Return instances owned by a specific user. |
-| `org_id` | Return instances in a specific organization. |
-| `date_range_begin` and `date_range_end` | Return instances created inside a date range. |
-| `free_text_search` | Search across instance names and related fields. |
+Use one of the accepted region values: `UAE`, `FR`, or `US`.
 
-For example, to list running instances in a specific region:
-
-```text
-curl --request GET \
-  --url "https://api.hivenet.com/v1/instances?status=running&region=us-east-1&size=20" \
-  --header "Authorization: Bearer $HIVENET_API_TOKEN" \
-  --header "Accept: application/json"
-```
-
-<Note>
-  Date range filters use ISO 8601 timestamps in UTC. Use `date_range_begin` and `date_range_end` together.
-</Note>
+For exact allowed values and limits, use the [`GET /instances`](/public-api/endpoints/list-instances) reference.
 
 ## Get one instance
 
-Use `GET /instances/{id}` when you need the current state of a single instance.
+Use [`GET /instances/{id}`](/public-api/endpoints/get-instance) to read the current state of a specific instance.
 
-```text
+```bash
 curl --request GET \
-  --url "https://api.hivenet.com/v1/instances/a1b2c3d4-e5f6-7890-abcd-ef1234567890" \
-  --header "Authorization: Bearer $HIVENET_API_TOKEN" \
+  --url "https://api.hivecompute.ai/v1/instances/a1b2c3d4-e5f6-7890-abcd-ef1234567890" \
+  --header "Authorization: Bearer $HIVENET_API_KEY" \
   --header "Accept: application/json"
 ```
-
-Use this endpoint after actions such as [start](/public-api/endpoints/start-instance) or [terminate](/public-api/endpoints/terminate-instance) to check whether the instance has reached the expected state.
 
 ## Start an instance
 
 Use [`POST /instances/{id}/start`](/public-api/endpoints/start-instance) to start a stopped instance.
 
-```text
+```bash
 curl --request POST \
-  --url "https://api.hivenet.com/v1/instances/a1b2c3d4-e5f6-7890-abcd-ef1234567890/start" \
-  --header "Authorization: Bearer $HIVENET_API_TOKEN" \
-  --header "Content-Type: application/json" \
-  --data '{
-    "reason_note": "Restarting the instance for a scheduled training run."
-  }'
-```
-
-The request body is optional. You can include `reason_note` when you want to keep a human-readable note for audit or operational context.
-
-After the request, the instance may move through `STARTING` before it reaches `RUNNING`. Check progress with [`GET /instances/{id}`](/public-api/endpoints/get-instance).
-
-```text
-curl --request GET \
-  --url "https://api.hivenet.com/v1/instances/a1b2c3d4-e5f6-7890-abcd-ef1234567890" \
-  --header "Authorization: Bearer $HIVENET_API_TOKEN" \
-  --header "Accept: application/json"
-```
-
-If the instance is already running, the API returns the current instance state.
-
-## Stop an instance
-
-Use [`POST /instances/{id}/stop`](/public-api/endpoints/stop-instance) to stop a running instance without deleting it. Stopped instances can be started again later with the same data.
-
-```text
-curl --request POST \
-  --url "https://api.hivenet.com/v1/instances/a1b2c3d4-e5f6-7890-abcd-ef1234567890/stop" \
-  --header "Authorization: Bearer $HIVENET_API_TOKEN" \
+  --url "https://api.hivecompute.ai/v1/instances/a1b2c3d4-e5f6-7890-abcd-ef1234567890/start" \
+  --header "Authorization: Bearer $HIVENET_API_KEY" \
   --header "Content-Type: application/json"
 ```
 
-The call returns as soon as the request is accepted. The instance moves through `STOPPING` and reaches `STOPPED` in the background. Poll [`GET /instances/{id}`](/public-api/endpoints/get-instance) until the `status` field shows `STOPPED`.
+If the instance is still stopping, the API can return `409 Conflict` with error code `CONFLICT`. Fetch the latest instance state before retrying.
 
-<Tip>
-  Use stop instead of terminate when you want to pause work and resume later. Terminated instances can't be recovered.
-</Tip>
+## Stop an instance
+
+Use [`POST /instances/{id}/stop`](/public-api/endpoints/stop-instance) to stop a running instance without terminating it.
+
+```bash
+curl --request POST \
+  --url "https://api.hivecompute.ai/v1/instances/a1b2c3d4-e5f6-7890-abcd-ef1234567890/stop" \
+  --header "Authorization: Bearer $HIVENET_API_KEY" \
+  --header "Content-Type: application/json"
+```
+
+Poll the instance until it reaches `STOPPED`. If the requested action conflicts with the current lifecycle state, the API can return `409 Conflict` with code `CONFLICT`.
 
 ## Terminate an instance
 
 Use [`POST /instances/{id}/terminate`](/public-api/endpoints/terminate-instance) to permanently terminate an instance.
 
 <Danger>
-  Terminating an instance is irreversible. A terminated instance can’t be restarted, and its data is deleted.
+  Termination is irreversible. A terminated instance can't be restarted, and its data is deleted.
 </Danger>
 
-```text
+```bash
 curl --request POST \
-  --url "https://api.hivenet.com/v1/instances/a1b2c3d4-e5f6-7890-abcd-ef1234567890/terminate" \
-  --header "Authorization: Bearer $HIVENET_API_TOKEN" \
-  --header "Content-Type: application/json" \
-  --data '{
-    "reason_note": "Terminating the instance after the workload completed."
-  }'
+  --url "https://api.hivecompute.ai/v1/instances/a1b2c3d4-e5f6-7890-abcd-ef1234567890/terminate" \
+  --header "Authorization: Bearer $HIVENET_API_KEY" \
+  --header "Content-Type: application/json"
 ```
 
-After the request, poll [`GET /instances/{id}`](/public-api/endpoints/get-instance) until the instance reaches `TERMINATED`.
+The terminate endpoint can also return `409 Conflict` with code `CONFLICT` when the current instance state prevents the action.
 
 ## Get instance logs
 
-Use [`GET /instances/{id}/logs`](/public-api/endpoints/get-instance-logs) to fetch recent container output from an instance.
+Use [`GET /instances/{id}/logs`](/public-api/endpoints/get-instance-logs) to fetch recent container output.
 
-```text
+```bash
 curl --request GET \
-  --url "https://api.hivenet.com/v1/instances/a1b2c3d4-e5f6-7890-abcd-ef1234567890/logs?lines=100" \
-  --header "Authorization: Bearer $HIVENET_API_TOKEN" \
+  --url "https://api.hivecompute.ai/v1/instances/a1b2c3d4-e5f6-7890-abcd-ef1234567890/logs?lines=100" \
+  --header "Authorization: Bearer $HIVENET_API_KEY" \
   --header "Accept: application/json"
 ```
 
-The `lines` query parameter controls how many log lines are returned. The default is `100`, and the maximum is `1000`.
+Logs are returned **newest first**. `entries[0]` is the most recent line.
 
 A shortened response looks like this:
 
@@ -194,12 +148,12 @@ A shortened response looks like this:
 {
   "entries": [
     {
-      "timestamp": "2026-06-26T10:01:00Z",
-      "message": "Training epoch 1/10 complete. Loss: 0.342"
+      "timestamp": "2026-08-10T10:02:15Z",
+      "line": "Training epoch 2/10 complete. Loss: 0.298"
     },
     {
-      "timestamp": "2026-06-26T10:02:15Z",
-      "message": "Training epoch 2/10 complete. Loss: 0.298"
+      "timestamp": "2026-08-10T10:01:00Z",
+      "line": "Training epoch 1/10 complete. Loss: 0.342"
     }
   ],
   "line_count": 2
@@ -210,32 +164,19 @@ A shortened response looks like this:
 
 <Steps>
   <Step title="List your instances">
-    Call [`GET /instances`](/public-api/endpoints/list-instances) to find the instance you want to inspect or manage.
+    Call [`GET /instances`](/public-api/endpoints/list-instances) and find the instance you want to manage.
   </Step>
-  <Step title="Save the instance ID">
-    Copy the `instance_id` from the response. You’ll need it for instance-specific requests.
-  </Step>
-  <Step title="Check the current state">
-    Call [`GET /instances/{id}`](/public-api/endpoints/get-instance) and read the `status` field before taking action.
+  <Step title="Check its current state">
+    Call [`GET /instances/{id}`](/public-api/endpoints/get-instance) before sending a lifecycle action.
   </Step>
   <Step title="Run the action">
-    [Start](/public-api/endpoints/start-instance), [stop](/public-api/endpoints/stop-instance), or [terminate](/public-api/endpoints/terminate-instance) the instance only after confirming that you’re using the correct ID.
+    Start, stop, or terminate the instance.
   </Step>
   <Step title="Poll for the final state">
-    Call [`GET /instances/{id}`](/public-api/endpoints/get-instance) again until the instance reaches the expected lifecycle state.
+    Call `GET /instances/{id}` until the instance reaches the expected state.
   </Step>
 </Steps>
 
-## Common issues
-
-| Issue | What to check |
-| :-- | :-- |
-| The list is empty | Confirm the token has access to the expected account or organization. |
-| The instance returns `404` | Check the instance ID and confirm the token can access that resource. |
-| The instance stays in a transitional state | Poll again after a short delay. Some actions take time to complete. |
-| Logs are empty | The instance may not have recent container output, or it may not have produced logs in the available window. |
-| A terminate request succeeded by mistake | Termination is permanent. Create a new instance if you need to run the workload again. |
-
 ## Next step
 
-Continue with [Use pagination and filters](/public-api/use-pagination-and-filters) to learn how to work with larger result sets and narrow API responses.
+Continue with [Use pagination and filters](/public-api/use-pagination-and-filters).


### PR DESCRIPTION
Updates the Public API docs to match the finalized eight-endpoint release surface. Removes SSH-key endpoint pages, updates production and staging base URLs, region values, log ordering, 409/CONFLICT handling, generic 500 messaging, error guidance, and related changelog copy. Also corrects the product changelog to describe managing existing instances rather than creating them.

The OpenAPI YAML itself was not changed in this branch because the newer unpublished YAML draft in the Mintlify editor is not exposed through the Git-backed MCP session. These documentation changes are intended to be reviewed alongside that updated YAML before publishing.

<!-- mintlify-editor-comments:start -->
Mintlify
---
0 threads from 0 users in Mintlify

- No unresolved comments
<!-- mintlify-editor-comments:end -->

<!-- mintlify-comment-->

<a href="https://app.mintlify.com/hivenet/hivenet/editor/admin-mcp%2Falign-api-docs-final-spec-42aa4fb?preview=%2Fchangelog&source=pr_comment" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://d3gk2c5xim1je2.cloudfront.net/assets/review-mintlify-editor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://d3gk2c5xim1je2.cloudfront.net/assets/review-mintlify-editor-light.svg"><img src="https://d3gk2c5xim1je2.cloudfront.net/assets/review-mintlify-editor-light.svg" alt="Review in Mintlify"></picture></a>

<!-- /mintlify-comment -->